### PR TITLE
Update Instagram Privacy Policy URL 

### DIFF
--- a/declarations/Instagram.history.json
+++ b/declarations/Instagram.history.json
@@ -1,0 +1,20 @@
+{
+  "Privacy Policy": [
+    {
+      "fetch": "https://privacycenter.instagram.com/policy",
+      "select": [
+        "div[role=\"main\"]"
+      ],
+      "remove": [
+        "div[aria-label=\"Copy Link\"]",
+        "[id='Related Articles']",
+        "fieldset"
+      ],
+      "filter": [
+        "removeTrackingIDs"
+      ],
+      "executeClientScripts": true,
+      "validUntil": "2022-07-11T04:33:26+04:00"
+    }
+  ]
+}

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -17,19 +17,16 @@
       "executeClientScripts": true
     },
     "Privacy Policy": {
-      "fetch": "https://privacycenter.instagram.com/policy",
+      "fetch": "https://mbasic.facebook.com/privacy/policy/printable/",
       "select": [
-        "div[role=\"main\"]"
+        "#root"
       ],
       "remove": [
-        "div[aria-label=\"Copy Link\"]",
-        "[id='Related Articles']",
-        "fieldset"
-      ],
-      "filter": [
-        "removeTrackingIDs"
-      ],
-      "executeClientScripts": true
+        ".k",
+        ".l",
+        ".bc",
+        "img[style=\"display:none\"]"
+      ]
     },
     "Community Guidelines": {
       "fetch": "https://help.instagram.com/477434105621119",


### PR DESCRIPTION
To fix issue #19 

I changed the URL to the printed version for easier selection. This is the same URL as Facebook's privacy policy, so took the same selectors from that file.