### PR TITLE
Update URL for English language, and fix selectors

### DIFF
--- a/declarations/TikTok.history.json
+++ b/declarations/TikTok.history.json
@@ -1,17 +1,29 @@
 {
   "Terms of Service": [
     {
-      "fetch": "https://www.tiktok.com/legal/terms-of-use?lang=en",
-      "select": {
-        "startBefore": "#terms-eea",
-        "endBefore": "#terms-in"
-      },
-      "validUntil": "2022-07-11T04:33:26+04:00"
+      "fetch": "https://www.tiktok.com/legal/terms-of-service-eea?lang=en",
+      "select": "article",
+      "remove": [
+        ".language-selection",
+        "img[style=\"display:none\"]"
+      ],
+      "validUntil": "2022-09-20T04:33:26+04:00"
+    }
+  ],
+  "Privacy Policy": [
+    {
+      "fetch": "https://www.tiktok.com/legal/page/eea/privacy-policy/en",
+      "select": "div[data-testid=\"policy-card\"]",
+      "remove": [
+        ".language-selection",
+        "img"
+      ],
+      "validUntil": "2022-09-20T04:33:26+04:00"
     }
   ],
   "In-App Purchases Policy": [
     {
-      "fetch": "https://www.tiktok.com/legal/virtual-items?lang=en",
+      "fetch": "https://www.tiktok.com/legal/virtual-items-eea?lang=en",
       "select": {
         "startBefore": "#virtual-items-eu",
         "endBefore": "#virtual-items-in"

--- a/declarations/TikTok.json
+++ b/declarations/TikTok.json
@@ -2,7 +2,7 @@
   "name": "TikTok",
   "documents": {
     "Terms of Service": {
-      "fetch": "https://www.tiktok.com/legal/terms-of-service-eea?lang=en",
+      "fetch": "https://www.tiktok.com/legal/terms-of-service-eea?lang=en&selection=true",
       "select": "article",
       "remove": [
         ".language-selection",
@@ -32,7 +32,7 @@
       "select": "article"
     },
     "In-App Purchases Policy": {
-      "fetch": "https://www.tiktok.com/legal/virtual-items-eea?lang=en",
+      "fetch": "https://www.tiktok.com/legal/virtual-items-eea?lang=en&selection=true",
       "select": "article",
       "remove": [
         ".language-selection",

--- a/declarations/TikTok.json
+++ b/declarations/TikTok.json
@@ -2,19 +2,20 @@
   "name": "TikTok",
   "documents": {
     "Terms of Service": {
-      "fetch": "https://www.tiktok.com/legal/terms-of-use?lang=en",
+      "fetch": "https://www.tiktok.com/legal/terms-of-service-eea?lang=en",
       "select": "article",
       "remove": [
         ".language-selection",
         "img"
-      ]
+      ],
+      "executeClientScripts": true
     },
     "Privacy Policy": {
-      "fetch": "https://www.tiktok.com/legal/privacy-policy-eea?lang=en",
-      "select": "article",
+      "fetch": "https://www.tiktok.com/legal/page/eea/privacy-policy/en",
+      "select": "div[data-testid=\"policy-card\"]",
       "remove": [
         ".language-selection",
-        "img[src=\"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHZpZXdCb3g9IjAgMCAzMCAzMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNC4xMTYxIDIwLjI1ODlMNS4xODMwNiAxMS4zMjU4QzQuOTM4OTggMTEuMDgxNyA0LjkzODk4IDEwLjY4NiA1LjE4MzA2IDEwLjQ0MTlMNi4wNjY5NCA5LjU1ODA2QzYuMzExMDIgOS4zMTM5OCA2LjcwNjc1IDkuMzEzOTggNi45NTA4MyA5LjU1ODA2TDE1IDE3LjYwNzJMMjMuMDQ5MiA5LjU1ODA2QzIzLjI5MzMgOS4zMTM5OCAyMy42ODkgOS4zMTM5OCAyMy45MzMxIDkuNTU4MDZMMjQuODE2OSAxMC40NDE5QzI1LjA2MSAxMC42ODYgMjUuMDYxIDExLjA4MTcgMjQuODE2OSAxMS4zMjU4TDE1Ljg4MzkgMjAuMjU4OUMxNS4zOTU3IDIwLjc0NyAxNC42MDQzIDIwLjc0NyAxNC4xMTYxIDIwLjI1ODlaIiBmaWxsPSJibGFjayIvPgo8L3N2Zz4K\"]"
+        "img"
       ]
     },
     "Community Guidelines": {
@@ -31,12 +32,13 @@
       "select": "article"
     },
     "In-App Purchases Policy": {
-      "fetch": "https://www.tiktok.com/legal/virtual-items?lang=en",
+      "fetch": "https://www.tiktok.com/legal/virtual-items-eea?lang=en",
       "select": "article",
       "remove": [
         ".language-selection",
         "img"
-      ]
+      ],
+      "executeClientScripts": true
     },
     "Trackers Policy": {
       "fetch": "https://www.tiktok.com/legal/tiktok-website-cookies-policy?lang=en",


### PR DESCRIPTION
Fix for issue #27 

- Privacy Policy was able to fetch English language with this fix
- Terms of Service and In-App Purchases Policy are still only fetching German language content. 

Is there a solution to this that can be found by editing the declaration files? I remember @MattiSG mentioning this could have to do with the server location in Germany, but I wanted to see if this can be fixed within the declaration file. 
