### PR TITLE
Add removeTrackingID filter to Facebook ToS

### DIFF
--- a/declarations/Facebook.history.json
+++ b/declarations/Facebook.history.json
@@ -3,6 +3,20 @@
     {
       "fetch": "https://www.facebook.com/legal/terms/plain_text_terms",
       "select": [
+        {
+          "startBefore": "div[role=main]",
+          "endBefore": "[role=\"separator\"]:first-child"
+        }
+      ],
+      "filter": [
+        "cleanUrls"
+      ],
+      "executeClientScripts": true,
+      "validUntil": "2022-07-12T04:33:26+04:00"
+    },
+    {
+      "fetch": "https://www.facebook.com/legal/terms/plain_text_terms",
+      "select": [
         ".ad2k81qe"
       ],
       "remove": [

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -10,7 +10,8 @@
         }
       ],
       "filter": [
-        "cleanUrls"
+        "cleanUrls",
+        "removeTrackingIDs"
       ],
       "executeClientScripts": true
     },


### PR DESCRIPTION
To fix blinking ToS that is tracking IDs in links