### PR TITLE
Add LinkedIn multi-page Community Guidelines

### DIFF
--- a/declarations/LinkedIn.json
+++ b/declarations/LinkedIn.json
@@ -48,14 +48,58 @@
       ]
     },
     "Community Guidelines": {
-      "fetch": "https://www.linkedin.com/legal/professional-community-policies",
+      "combine": [
+        {
+          "fetch": "https://www.linkedin.com/legal/professional-community-policies",
+          "select": [
+            "main"
+          ],
+          "remove": [
+            ".banner__image-container",
+            ".component-standaloneImage"
+          ]
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137369"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137374"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137376"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137373"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137375"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137371"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137377"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137378"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137370"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137374"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137372"
+        }
+      ],
       "select": [
-        "main"
+        ".hc-page__content"
       ],
       "remove": [
-        ".banner__image-container",
-        ".component-standaloneImage"
-      ]
+        "[data-test-id=\"helpfulness-module\"]"
+      ],
+      "executeClientScripts": true
     }
   }
 }


### PR DESCRIPTION
I am adding the extended Community Guidelines. I did not add the history file entry because I wanted to see how I should proceed with this since the community guidelines were not broken. 

In this situation can I write a history file that overwrites all of the history of the LinkedIn CG to include the multi-page tracking? 