### PR TITLE
Remove blinking date from LinkedIn Community Guidelines

### DIFF
--- a/declarations/LinkedIn.history.json
+++ b/declarations/LinkedIn.history.json
@@ -22,6 +22,63 @@
         ".component-standaloneImage"
       ],
       "validUntil": "2022-09-20T15:22:35Z"
+    },
+    {
+      "select": [
+        ".hc-page__content"
+      ],
+      "remove": [
+        ".helpfulness",
+        "[data-test-id*=\"article-page-subtext\"]",
+        ".answer-footer > p"
+      ],
+      "combine": [
+        {
+          "fetch": "https://www.linkedin.com/legal/professional-community-policies",
+          "select": [
+            "main"
+          ],
+          "remove": [
+            ".banner__image-container",
+            ".component-standaloneImage"
+          ]
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137369"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137374"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137376"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137373"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137375"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137371"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137377"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137378"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137370"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137374"
+        },
+        {
+          "fetch": "https://www.linkedin.com/help/linkedin/answer/137372"
+        }
+      ],
+      "executeClientScripts": true,
+      "validUntil": "2022-11-02T17:30:51Z"
     }
   ]
 }

--- a/declarations/LinkedIn.json
+++ b/declarations/LinkedIn.json
@@ -52,7 +52,9 @@
         ".hc-page__content"
       ],
       "remove": [
-        ".helpfulness"
+        ".helpfulness",
+        "[data-test-id*=\"article-page-subtext\"]",
+        ".answer-footer > p"
       ],
       "combine": [
         {


### PR DESCRIPTION
I tried using the [ recommended filter ](https://github.com/OpenTermsArchive/p2b-compliance-declarations/blob/main/declarations/Ecosia.filters.js) but I could not find an ISO datetime to select when inspecting the page. 

This is not the ideal solution to remove this information but was the only solution I could see to stop the blinking. 

Please let me know if you know of another way to select ISO datetime 🙏