### PR TITLE
Remove .img from Facebook Community Guidelines

### DIFF
--- a/declarations/Facebook.filters.js
+++ b/declarations/Facebook.filters.js
@@ -48,6 +48,22 @@ export function removeEmptyAnchorsLinks(document) {
     link.removeAttribute('href'));
 }
 
+export function removeRefParam(document) {
+  removeQueryParam(document, 'ref');
+}
+
+export function removeHelprefQueryParam(document) {
+  removeQueryParam(document, 'helpref');
+}
+
+export function removeTrackingIDsE(document) {
+  removeQueryParam(document, 'e');
+}
+
+export function removeRevisionQueryParam(document) {
+  removeQueryParam(document, 'revision');
+}
+
 export function removeTrackingIDs(document) {
   removeQueryParam(document, 'h');
 }

--- a/declarations/Facebook.history.json
+++ b/declarations/Facebook.history.json
@@ -208,6 +208,105 @@
         }
       ],
       "validUntil": "2022-11-03T00:30:02Z"
+    },
+    {
+      "select": [
+        "h1",
+        {
+          "startBefore": "#policy-details h4:first-child",
+          "endAfter": "#policy-details"
+        }
+      ],
+      "filter": [
+        "removeTrackingIDs"
+      ],
+      "combine": [
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/",
+          "select": [
+            {
+              "startBefore": "h1",
+              "endBefore": "body > div > section:last-of-type h6"
+            }
+          ],
+          "filter": [
+            "removeTrackingIDs"
+          ]
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/violence-incitement/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/dangerous-individuals-organizations/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/coordinating-harm-publicizing-crime/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/regulated-goods/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/fraud-deception/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/suicide-self-injury/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/child-sexual-exploitation-abuse-nudity/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/sexual-exploitation-adults/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/bullying-harassment/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/human-exploitation/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/privacy-violations-image-privacy-rights/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/hate-speech/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/violent-graphic-content/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/adult-nudity-sexual-activity/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/sexual-solicitation/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/account-integrity-and-authentic-identity/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/spam/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/cybersecurity/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/inauthentic-behavior/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/misinformation/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/memorialization/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/intellectual-property/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/user-requests/"
+        },
+        {
+          "fetch": "https://transparency.fb.com/policies/community-standards/additional-protection-minors/"
+        }
+      ],
+      "validUntil": "2022-10-28T18:30:09Z"
     }
   ]
 }

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -106,8 +106,14 @@
           "endAfter": "#policy-details"
         }
       ],
+      "remove": "img[src*='https://scontent']",
       "filter": [
-        "removeTrackingIDs"
+        "removeRefParam",
+        "removeHelprefQueryParam",
+        "removeTrackingID",
+        "removeLocaleQueryParam",
+        "removeRevisionQueryParam",
+        "removeTrackingIDsE"
       ],
       "combine": [
         {
@@ -119,10 +125,15 @@
             }
           ],
           "remove": [
-            ".img"
+            "img[src*='https://scontent']"
           ],
           "filter": [
-            "removeTrackingIDs"
+            "removeRefParam",
+            "removeHelprefQueryParam",
+            "removeTrackingID",
+            "removeLocaleQueryParam",
+            "removeRevisionQueryParam",
+            "removeTrackingIDsE"
           ]
         },
         {

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -118,6 +118,9 @@
               "endBefore": "body > div > section:last-of-type h6"
             }
           ],
+          "remove": [
+            ".img"
+          ],
           "filter": [
             "removeTrackingIDs"
           ]

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -106,15 +106,7 @@
           "endAfter": "#policy-details"
         }
       ],
-      "remove": "img[src*='https://scontent']",
-      "filter": [
-        "removeRefParam",
-        "removeHelprefQueryParam",
-        "removeTrackingID",
-        "removeLocaleQueryParam",
-        "removeRevisionQueryParam",
-        "removeTrackingIDsE"
-      ],
+      "remove": ".img",
       "combine": [
         {
           "fetch": "https://transparency.fb.com/policies/community-standards/",
@@ -125,15 +117,7 @@
             }
           ],
           "remove": [
-            "img[src*='https://scontent']"
-          ],
-          "filter": [
-            "removeRefParam",
-            "removeHelprefQueryParam",
-            "removeTrackingID",
-            "removeLocaleQueryParam",
-            "removeRevisionQueryParam",
-            "removeTrackingIDsE"
+            ".img"
           ]
         },
         {

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -106,7 +106,7 @@
           "endAfter": "#policy-details"
         }
       ],
-      "remove": ".img",
+      "remove": "137145103_308994903869841_4708570808613729754_n.jpg",
       "combine": [
         {
           "fetch": "https://transparency.fb.com/policies/community-standards/",
@@ -117,7 +117,7 @@
             }
           ],
           "remove": [
-            ".img"
+            "137145103_308994903869841_4708570808613729754_n.jpg"
           ]
         },
         {

--- a/declarations/Facebook.json
+++ b/declarations/Facebook.json
@@ -106,7 +106,7 @@
           "endAfter": "#policy-details"
         }
       ],
-      "remove": "137145103_308994903869841_4708570808613729754_n.jpg",
+      "remove": "4708570808613729754_n.jpg",
       "combine": [
         {
           "fetch": "https://transparency.fb.com/policies/community-standards/",
@@ -117,7 +117,7 @@
             }
           ],
           "remove": [
-            "137145103_308994903869841_4708570808613729754_n.jpg"
+            "4708570808613729754_n.jpg"
           ]
         },
         {


### PR DESCRIPTION
I tried removeQueryParam used from france-elections repo. I still do not know how to remove this blinking that keeps showing up with this and Instagram so I tried removing .img and QueryParams. 