### PR TITLE
Update engine installation and CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ambanum/OpenTermsArchive
       - name: Install SSH key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # fetch all history for all branches and tags
+          fetch-depth: 0  # fetch all history in order to identify modified declarations
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
   validate_schema:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: npm install
@@ -19,10 +19,10 @@ jobs:
   validate_modified_declarations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch all history for all branches and tags
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -2,16 +2,15 @@
   "type": "module",
   "license": "EUPL-1.2",
   "scripts": {
-    "lint": "ota-lint-declarations",
-    "test": "ota-validate-declarations",
-    "test:schema": "npm run test -- --schema-only",
-    "test:modified": "npm run test -- --modified",
-    "track": "ota-track",
-    "track:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r npm run track -- --services"
-  },
+    "lint": "ota lint",
+    "test": "ota validate",
+    "test:schema": "ota validate --schema-only",
+    "test:modified": "ota validate --modified",
+    "track": "ota track",
+    "track:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r ota track --services"
   },
   "dependencies": {
-    "@opentermsarchive/engine": "^0.17",
+    "@opentermsarchive/engine": "^0.20",
     "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
     "track": "ota-track",
     "track:modified": "git diff --name-only HEAD $(git merge-base HEAD origin/main) -- ./declarations/ | grep -v .history | grep -v .filters | sed 's/declarations\\///g' | sed 's/.json//g' | sed 's/.*/\"&\"/' | xargs -r npm run track -- --services"
   },
-  "devDependencies": {
-    "open-terms-archive": "git+https://git@github.com/ambanum/OpenTermsArchive.git#main"
   },
   "dependencies": {
+    "@opentermsarchive/engine": "^0.17",
     "isomorphic-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
Follows https://github.com/ambanum/OpenTermsArchive/pull/978 and https://github.com/ambanum/OpenTermsArchive/pull/957. Proof that this update works can be found in [this job run](https://github.com/OpenTermsArchive/pga-declarations/actions/runs/3686251390).

Until this PR is merged, all tests will fail because the command syntax has changed.

Once this PR is merged, if you use this repository locally, you will need to run `npm install` on your machine to update your dependencies 🙂

