### PR TITLE
Remove blinking links from Instagram tos

### DIFF
--- a/declarations/Instagram.filters.js
+++ b/declarations/Instagram.filters.js
@@ -50,3 +50,13 @@ function removeQueryParam(document, queryParam) {
     }
   });
 }
+
+export function removeLinks(document) {
+  const elements = document.querySelectorAll('a');
+
+  elements.forEach(element => {
+    if (element.hasAttribute('href')) {
+      element.removeAttribute('href');
+    }
+  });
+}

--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -10,16 +10,11 @@
         "div[aria-label=\"Copy Link\"]",
         "[id='Related Articles']",
         "fieldset",
-        "img[src*='https://scontent']"
+        "img[src*='https://scontent']",
+        "img[src*='static.xx.fbcdn.net']"
       ],
       "filter": [
-        "cleanUrls",
-        "removeRefParam",
-        "removeHelprefQueryParam",
-        "removeTrackingIDs",
-        "removeLocaleQueryParam",
-        "removeRevisionQueryParam",
-        "removeTrackingIDsE"
+        "removeLinks"
       ],
       "executeClientScripts": true
     },


### PR DESCRIPTION
Remove blinking links with this filter. The same was used in the [clean-dataset](https://github.com/OpenTermsArchive/pga-declarations/pull/115) branch that has not been merged yet. 

No history file was added because this issue has been ongoing since the document has been first tracked