### PR TITLE
Update Instagram Community Guidelines

### DIFF
--- a/declarations/Instagram.json
+++ b/declarations/Instagram.json
@@ -43,7 +43,7 @@
       ],
       "combine": [
         {
-          "fetch": "https://help.instagram.com/126382350847838?helpref=faq_content",
+          "fetch": "https://help.instagram.com/477434105621119",
           "select": [
             "div[role=\"main\"]"
           ],


### PR DESCRIPTION
Replace a link to the "Copyright Declarations" page with a link to the "Community Guidelines" page  