### PR TITLE
Fix X blink on links

### DIFF
--- a/declarations/X.filters.js
+++ b/declarations/X.filters.js
@@ -1,0 +1,8 @@
+export function useXHelpCenterBaseURL(document) {
+  const TwitterHelpCenterBaseURL = 'https://help.twitter.com';
+  const XHelpCenterBaseURL = 'https://help.x.com';
+
+  document.querySelectorAll(`a[href^="${TwitterHelpCenterBaseURL}"]`).forEach(link => {
+    link.href = link.href.replace(TwitterHelpCenterBaseURL, XHelpCenterBaseURL);
+  });
+}

--- a/declarations/X.history.json
+++ b/declarations/X.history.json
@@ -1,0 +1,265 @@
+{
+  "Terms of Service": [
+    {
+      "fetch": "https://twitter.com/tos",
+      "remove": [
+        ".twtr-icon--base",
+        ".p05-chapter-navigation",
+        "[style='display: none;']",
+        ".twtr-overlay__icon",
+        ".p21-hidden-content",
+        ".ct01__background",
+        ".ct17__background",
+        ".b04__image",
+        ".twtr-hidden--lg"
+      ],
+      "select": [
+        "main[id=twtr-main]"
+      ],
+      "validUntil": "2024-06-24T12:12:15.403062Z"
+    }
+  ],
+  "Privacy Policy": [
+    {
+      "fetch": "https://twitter.com/en/privacy",
+      "remove": [
+        ".twtr-icon--base",
+        ".p05-chapter-navigation",
+        "[style='display: none;']",
+        ".twtr-overlay__icon",
+        ".p21-hidden-content",
+        ".ct01__background",
+        ".ct17__background",
+        ".b04__image",
+        ".twtr-hidden--lg"
+      ],
+      "select": [
+        "main[id=twtr-main]"
+      ],
+      "validUntil": "2024-06-24T12:12:15.403062Z"
+    }
+  ],
+  "Developer Terms": [
+    {
+      "fetch": "https://developer.twitter.com/en/developer-terms/agreement",
+      "select": [
+        "#twtr-main"
+      ],
+      "remove": [
+        ".u07__close:nth-child(2)",
+        ".u07__notification"
+      ],
+      "validUntil": "2024-06-24T12:12:15.403062Z"
+    }
+  ],
+  "Copyright Claims Policy": [
+    {
+      "fetch": "https://help.twitter.com/en/rules-and-policies/copyright-policy",
+      "select": [
+        ".ct01__wrapper"
+      ],
+      "remove": [
+        ".b24__wrapper",
+        ".inherit",
+        ".twtr-type--roman-100r",
+        ".u11__breadcrumbs-list:nth-child(2)",
+        ".IconButton",
+        ".b04-image"
+      ],
+      "validUntil": "2024-05-17T00:38:36Z"
+    }
+  ],
+  "Law Enforcement Guidelines": [
+    {
+      "fetch": "https://help.twitter.com/en/rules-and-policies/twitter-law-enforcement-support",
+      "select": [
+        ".aem-Grid"
+      ],
+      "remove": [
+        ".twtr-type--roman-100r",
+        ".u11__breadcrumbs-list:nth-child(2)",
+        ".twtr-type--headline-md",
+        ".b24__wrapper",
+        ".b17",
+        ".u11__mobile-header",
+        ".twtr-component--first > .b02-v2 > ul",
+        ".twtr-component--first b"
+      ],
+      "validUntil": "2024-05-17T00:38:38.000Z"
+    }
+  ],
+  "Trackers Policy": [
+    {
+      "fetch": "https://help.twitter.com/en/rules-and-policies/twitter-cookies",
+      "select": [
+        ".aem-Grid"
+      ],
+      "remove": [
+        ".u11__breadcrumbs-mobile-modal",
+        ".twtr-type--roman-100r",
+        ".twtr-type--headline-md",
+        ".b24__wrapper",
+        ".b17"
+      ],
+      "validUntil": "2024-05-16T06:39:10.000Z"
+    }
+  ],
+  "Data Processor Agreement": [
+    {
+      "fetch": "https://help.twitter.com/en/rules-and-policies/data-processing-legal-bases",
+      "select": [
+        ".aem-Grid"
+      ],
+      "remove": [
+        ".u11__breadcrumbs-mobile-modal",
+        ".twtr-type--roman-100r",
+        ".twtr-type--headline-md",
+        ".b24__wrapper",
+        ".b17"
+      ],
+      "validUntil": "2024-05-23T00:38:49.000Z"
+    }
+  ],
+  "Community Guidelines": [
+    {
+      "select": [
+        {
+          "startBefore": "h1",
+          "endAfter": "[class*=\"rich-text-v\"]"
+        }
+      ],
+      "combine": [
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/x-rules"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/violent-speech"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/violent-entities"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/sexual-exploitation-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/abusive-behavior"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/hateful-conduct-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/perpetrators-of-violent-attacks"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/glorifying-self-harm"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/media-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/regulated-goods-services"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/personal-information"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/intimate-media"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/platform-manipulation"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/election-integrity-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/twitter-impersonation-and-deceptive-identities-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/manipulated-media"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/x-trademark-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/x-username-squatting"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/copypasta-duplicate-content"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/financial-scam"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/financial-scam"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/abusive-profile"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/automated-claims-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/counterfeit-goods-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/public-interest"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/x-limits"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/x-reach-limited"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/enforcement-options"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/x-moments-guidelines-and-principles"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/fair-use-policy"
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/copyright-policy",
+          "select": [
+            {
+              "startBefore": "h1",
+              "endBefore": "[class*=\"share-tweet\"]"
+            }
+          ],
+          "remove": [
+            "[class*=\"twtr-type--headline-md\"]"
+          ]
+        },
+        {
+          "fetch": "https://help.twitter.com/en/rules-and-policies/enforcement-philosophy"
+        }
+      ],
+      "validUntil": "2024-05-17T00:38:58.000Z"
+    }
+  ],
+  "Deceased Users": [
+    {
+      "fetch": "https://help.twitter.com/en/rules-and-policies/contact-twitter-about-media-on-a-deceased-family-members-account",
+      "select": [
+        {
+          "startBefore": "h1",
+          "endAfter": "[class*=\"rich-text-v\"]"
+        }
+      ],
+      "validUntil": "Feb 21, 2024, 1:36 PM GMT+1"
+    }
+  ],
+  "Data Controller Agreement": [
+    {
+      "fetch": "https://help.twitter.com/en/rules-and-policies/data-processing-legal-bases",
+      "select": [
+        {
+          "startBefore": "h1",
+          "endBefore": "[class*=b24-share-tweet]"
+        }
+      ],
+      "validUntil": "2024-05-23T00:38:55.000Z"
+    }
+  ]
+}

--- a/declarations/X.history.json
+++ b/declarations/X.history.json
@@ -247,7 +247,7 @@
           "endAfter": "[class*=\"rich-text-v\"]"
         }
       ],
-      "validUntil": "Feb 21, 2024, 1:36 PM GMT+1"
+      "validUntil": "2024-02-21T12:36:11.000Z"
     }
   ],
   "Data Controller Agreement": [

--- a/declarations/X.json
+++ b/declarations/X.json
@@ -57,6 +57,9 @@
         ".u11__breadcrumbs-list:nth-child(2)",
         ".IconButton",
         ".b04-image"
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ]
     },
     "Law Enforcement Guidelines": {
@@ -73,6 +76,9 @@
         ".u11__mobile-header",
         ".twtr-component--first > .b02-v2 > ul",
         ".twtr-component--first b"
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ]
     },
     "Trackers Policy": {
@@ -86,6 +92,9 @@
         ".twtr-type--headline-md",
         ".b24__wrapper",
         ".b17"
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ]
     },
     "Data Processor Agreement": {
@@ -99,6 +108,9 @@
         ".twtr-type--headline-md",
         ".b24__wrapper",
         ".b17"
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ]
     },
     "Community Guidelines": {
@@ -107,6 +119,9 @@
           "startBefore": "h1",
           "endAfter": "[class*=\"rich-text-v\"]"
         }
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ],
       "combine": [
         {
@@ -223,6 +238,9 @@
           "startBefore": "h1",
           "endAfter": "[class*=\"rich-text-v\"]"
         }
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ]
     },
     "Data Controller Agreement": {
@@ -232,6 +250,9 @@
           "startBefore": "h1",
           "endBefore": "[class*=b24-share-tweet]"
         }
+      ],
+      "filter": [
+        "useXHelpCenterBaseURL"
       ]
     }
   }

--- a/declarations/X.json
+++ b/declarations/X.json
@@ -2,7 +2,7 @@
   "name": "X",
   "documents": {
     "Terms of Service": {
-      "fetch": "https://twitter.com/tos",
+      "fetch": "https://x.com/tos",
       "remove": [
         ".twtr-icon--base",
         ".p05-chapter-navigation",
@@ -19,7 +19,7 @@
       ]
     },
     "Privacy Policy": {
-      "fetch": "https://twitter.com/en/privacy",
+      "fetch": "https://x.com/en/privacy",
       "remove": [
         ".twtr-icon--base",
         ".p05-chapter-navigation",
@@ -36,7 +36,7 @@
       ]
     },
     "Developer Terms": {
-      "fetch": "https://developer.twitter.com/en/developer-terms/agreement",
+      "fetch": "https://developer.x.com/en/developer-terms/agreement",
       "select": [
         "#twtr-main"
       ],
@@ -46,7 +46,7 @@
       ]
     },
     "Copyright Claims Policy": {
-      "fetch": "https://help.twitter.com/en/rules-and-policies/copyright-policy",
+      "fetch": "https://help.x.com/en/rules-and-policies/copyright-policy",
       "select": [
         ".ct01__wrapper"
       ],
@@ -63,7 +63,7 @@
       ]
     },
     "Law Enforcement Guidelines": {
-      "fetch": "https://help.twitter.com/en/rules-and-policies/twitter-law-enforcement-support",
+      "fetch": "https://help.x.com/en/rules-and-policies/twitter-law-enforcement-support",
       "select": [
         ".aem-Grid"
       ],
@@ -82,7 +82,7 @@
       ]
     },
     "Trackers Policy": {
-      "fetch": "https://help.twitter.com/en/rules-and-policies/twitter-cookies",
+      "fetch": "https://help.x.com/en/rules-and-policies/twitter-cookies",
       "select": [
         ".aem-Grid"
       ],
@@ -98,7 +98,7 @@
       ]
     },
     "Data Processor Agreement": {
-      "fetch": "https://help.twitter.com/en/rules-and-policies/data-processing-legal-bases",
+      "fetch": "https://help.x.com/en/rules-and-policies/data-processing-legal-bases",
       "select": [
         ".aem-Grid"
       ],
@@ -125,97 +125,97 @@
       ],
       "combine": [
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/x-rules"
+          "fetch": "https://help.x.com/en/rules-and-policies/x-rules"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/violent-speech"
+          "fetch": "https://help.x.com/en/rules-and-policies/violent-speech"
         },
         {
           "fetch": "https://help.x.com/en/rules-and-policies/violent-entities"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/sexual-exploitation-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/sexual-exploitation-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/abusive-behavior"
+          "fetch": "https://help.x.com/en/rules-and-policies/abusive-behavior"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/hateful-conduct-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/hateful-conduct-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/perpetrators-of-violent-attacks"
+          "fetch": "https://help.x.com/en/rules-and-policies/perpetrators-of-violent-attacks"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/glorifying-self-harm"
+          "fetch": "https://help.x.com/en/rules-and-policies/glorifying-self-harm"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/media-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/media-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/regulated-goods-services"
+          "fetch": "https://help.x.com/en/rules-and-policies/regulated-goods-services"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/personal-information"
+          "fetch": "https://help.x.com/en/rules-and-policies/personal-information"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/intimate-media"
+          "fetch": "https://help.x.com/en/rules-and-policies/intimate-media"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/platform-manipulation"
+          "fetch": "https://help.x.com/en/rules-and-policies/platform-manipulation"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/election-integrity-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/election-integrity-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/twitter-impersonation-and-deceptive-identities-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/twitter-impersonation-and-deceptive-identities-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/manipulated-media"
+          "fetch": "https://help.x.com/en/rules-and-policies/manipulated-media"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/x-trademark-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/x-trademark-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/x-username-squatting"
+          "fetch": "https://help.x.com/en/rules-and-policies/x-username-squatting"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/copypasta-duplicate-content"
+          "fetch": "https://help.x.com/en/rules-and-policies/copypasta-duplicate-content"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/financial-scam"
+          "fetch": "https://help.x.com/en/rules-and-policies/financial-scam"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/financial-scam"
+          "fetch": "https://help.x.com/en/rules-and-policies/financial-scam"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/abusive-profile"
+          "fetch": "https://help.x.com/en/rules-and-policies/abusive-profile"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/automated-claims-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/automated-claims-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/counterfeit-goods-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/counterfeit-goods-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/public-interest"
+          "fetch": "https://help.x.com/en/rules-and-policies/public-interest"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/x-limits"
+          "fetch": "https://help.x.com/en/rules-and-policies/x-limits"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/x-reach-limited"
+          "fetch": "https://help.x.com/en/rules-and-policies/x-reach-limited"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/enforcement-options"
+          "fetch": "https://help.x.com/en/rules-and-policies/enforcement-options"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/x-moments-guidelines-and-principles"
+          "fetch": "https://help.x.com/en/rules-and-policies/x-moments-guidelines-and-principles"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/fair-use-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/fair-use-policy"
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/copyright-policy",
+          "fetch": "https://help.x.com/en/rules-and-policies/copyright-policy",
           "select": [
             {
               "startBefore": "h1",
@@ -227,12 +227,12 @@
           ]
         },
         {
-          "fetch": "https://help.twitter.com/en/rules-and-policies/enforcement-philosophy"
+          "fetch": "https://help.x.com/en/rules-and-policies/enforcement-philosophy"
         }
       ]
     },
     "Deceased Users": {
-      "fetch": "https://help.twitter.com/en/rules-and-policies/contact-twitter-about-media-on-a-deceased-family-members-account",
+      "fetch": "https://help.x.com/en/rules-and-policies/contact-twitter-about-media-on-a-deceased-family-members-account",
       "select": [
         {
           "startBefore": "h1",
@@ -244,7 +244,7 @@
       ]
     },
     "Data Controller Agreement": {
-      "fetch": "https://help.twitter.com/en/rules-and-policies/data-processing-legal-bases",
+      "fetch": "https://help.x.com/en/rules-and-policies/data-processing-legal-bases",
       "select": [
         {
           "startBefore": "h1",

--- a/declarations/X.json
+++ b/declarations/X.json
@@ -128,13 +128,19 @@
           "fetch": "https://help.x.com/en/rules-and-policies/x-rules"
         },
         {
-          "fetch": "https://help.x.com/en/rules-and-policies/violent-speech"
+          "fetch": "https://help.x.com/en/rules-and-policies/violent-content",
+          "select": [
+            "main"
+          ]
         },
         {
           "fetch": "https://help.x.com/en/rules-and-policies/violent-entities"
         },
         {
-          "fetch": "https://help.x.com/en/rules-and-policies/sexual-exploitation-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/child-safety",
+          "select": [
+            "main"
+          ]
         },
         {
           "fetch": "https://help.x.com/en/rules-and-policies/abusive-behavior"
@@ -149,7 +155,10 @@
           "fetch": "https://help.x.com/en/rules-and-policies/glorifying-self-harm"
         },
         {
-          "fetch": "https://help.x.com/en/rules-and-policies/media-policy"
+          "fetch": "https://help.x.com/en/rules-and-policies/adult-content",
+          "select": [
+            "main"
+          ]
         },
         {
           "fetch": "https://help.x.com/en/rules-and-policies/regulated-goods-services"


### PR DESCRIPTION
This changeset fixes the blink issue on X documents by replacing the base URL from `help.twitter.com` to `help.x.com` on the links. I took the opportunity to correct the incorrect URLs and fix issue #260. 

@smmkolesnikov I assigned you to the review to ensure you had a chance to look at the [filter](https://github.com/OpenTermsArchive/pga-declarations/pull/327/files#diff-6ad961593ecff2b93281a463adb3e33bb7976f57c7ee12778065e1469ed7664f) I implemented and the [related documentation](https://docs.opentermsarchive.org/terms/reference/#filter).