### PR TITLE
X community guidelines - remove duplicated "Financial scam policy"

### DIFF
--- a/declarations/X.json
+++ b/declarations/X.json
@@ -194,9 +194,6 @@
           "fetch": "https://help.x.com/en/rules-and-policies/financial-scam"
         },
         {
-          "fetch": "https://help.x.com/en/rules-and-policies/financial-scam"
-        },
-        {
           "fetch": "https://help.x.com/en/rules-and-policies/abusive-profile"
         },
         {


### PR DESCRIPTION
The X Community Guidelines are combined of multiple pages (32 resp. 31).

[X's Financial scam policy](https://help.x.com/en/rules-and-policies/financial-scam) is included twice. It also appears twice in the [X community guidelines in pga-versions](https://github.com/OpenTermsArchive/pga-versions/blob/cfa6efb0c4adabb2a2a9e85e91c59215ef03000f/X/Community%20Guidelines.md#financial-scam-policy).