### PR TITLE
Expose collection metadata

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,9 @@
       "title": "pga",
       "versionsRepositoryURL": "https://github.com/OpenTermsArchive/pga-versions"
     },
+    "logger": {
+      "timestampPrefix": false
+    },
     "collection-api": {
       "port": 3000,
       "basePath": "/collection-api"

--- a/deployment/pm2.config.cjs
+++ b/deployment/pm2.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
       max_restarts: 2,
       min_uptime: '1h', // Set a relatively high duration (more than the longest run) so that restarts that occur before this duration has elapsed are considered unstable.
       restart_delay: 3 * 60 * 60 * 1000,  // likely related to a connectivity problem that will take some time to be fixed
+      log_date_format: "YYYY-MM-DDTHH:mm:ssZ"
     },
     {
       name: 'ota-api',
@@ -15,7 +16,8 @@ module.exports = {
       min_uptime: '10s',
       max_restarts: 10,
       restart_delay: 1000,
-      exponential_backoff_restart_delay: true
+      exponential_backoff_restart_delay: true,
+      log_date_format: "YYYY-MM-DDTHH:mm:ssZ"
     },
     {
       name: 'ota-release',
@@ -24,7 +26,8 @@ module.exports = {
       min_uptime: '10s',
       max_restarts: 10,
       restart_delay: 60 * 60 * 1000,  // likely related to a GitHub availability problem that will take some time to be fixed
-      exponential_backoff_restart_delay: true
+      exponential_backoff_restart_delay: true,
+      log_date_format: "YYYY-MM-DDTHH:mm:ssZ"
     }
   ],
 };

--- a/metadata.yml
+++ b/metadata.yml
@@ -2,9 +2,9 @@ id: pga
 name: Platform Governance Archive
 tagline: Major global social media services
 description: |
-  The **Plateform Governance Archive** (PGA) collection tracks the terms of major global social media services.
+  The **Platform Governance Archive** (PGA) collection tracks the terms of major global social media services.
   
-  These data are maintained and analysed by the [Platform Governance Archive](https://www.platformgovernancearchive.org/) at the Universität Bremen's [Center for Media Communication and Information Research (ZeMKI)](https://www.uni-bremen.de/zemki).
+  This data is maintained and analysed by the [Platform Governance Archive](https://www.platformgovernancearchive.org/) at the Universität Bremen's [Center for Media Communication and Information Research (ZeMKI)](https://www.uni-bremen.de/zemki).
   
   This initiative offers researchers, journalists and citizens the tools to analyze how platforms structure and regulate communication and interaction in our societies.
   
@@ -50,7 +50,7 @@ i18n:
   fr: 
     tagline: Médias sociaux mondiaux majeurs
     description: | 
-      La collection **Plateform Governance Archive** (PGA) suit les conditions d'utilisation des principaux services de médias sociaux.
+      La collection **Platform Governance Archive** (PGA) suit les conditions d'utilisation des principaux services de médias sociaux.
       
       Ces données sont maintenues et analysées par la [Platform Governance Archive](https://www.platformgovernancearchive.org/) du [Center for Media Communication and Information Research (ZeMKI)](https://www.uni-bremen.de/zemki) de l'Université de Brême.
       

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,0 +1,64 @@
+id: pga
+name: Platform Governance Archive
+tagline: Major global social media services
+description: |
+  The **Plateform Governance Archive** (PGA) collection tracks the terms of major global social media services.
+  
+  These data are maintained and analysed by the [Platform Governance Archive](https://www.platformgovernancearchive.org/) at the Universität Bremen's [Center for Media Communication and Information Research (ZeMKI)](https://www.uni-bremen.de/zemki).
+  
+  This initiative offers researchers, journalists and citizens the tools to analyze how platforms structure and regulate communication and interaction in our societies.
+  
+  It also aims to promote greater transparency and accountability of these powerful digital services.
+dataset: https://github.com/OpenTermsArchive/pga-versions/releases
+declarations: https://github.com/OpenTermsArchive/pga-declarations
+versions: https://github.com/OpenTermsArchive/pga-versions
+snapshots: https://github.com/OpenTermsArchive/pga-snapshots
+donations: https://opencollective.com/opentermsarchive
+logo: https://opentermsarchive.org/images/collections/platform-governance-archive.png
+languages: [en]
+jurisdictions: [EU]
+trackingPeriods:
+  - startDate: 2022-04-20
+    schedule: "30 */12 * * *"
+    serverLocation: Bremen, DE
+governance:
+  hosts:
+    - name: Centre for Media, Communication and Information Research
+      url: https://zemki.uni-bremen.de
+      logo: https://opentermsarchive.org/images/contributors/zemki.png
+  administrators:
+    - name: Open Terms Archive
+      url: https://opentermsarchive.org
+      logo: https://opentermsarchive.org/images/logo/logo-open-terms-archive-black-small.png
+  curators:
+    - name: Platform Governance Archive
+      url: https://www.platformgovernancearchive.org
+      logo: https://opentermsarchive.org/images/contributors/pga.png
+  maintainers:
+    - name: Platform Governance Archive
+      url: https://www.platformgovernancearchive.org
+      logo: https://opentermsarchive.org/images/contributors/pga.png
+  sponsors:
+    - name: Ministry for Europe and Foreign Affairs
+      url: https://www.diplomatie.gouv.fr/en/
+      logo: https://opentermsarchive.org/images/contributors/meae.png
+    - name: Centre for Media, Communication and Information Research
+      url: https://zemki.uni-bremen.de
+      logo: https://opentermsarchive.org/images/contributors/zemki.png
+
+i18n:
+  fr: 
+    tagline: Médias sociaux mondiaux majeurs
+    description: | 
+      La collection **Plateform Governance Archive** (PGA) suit les conditions d'utilisation des principaux services de médias sociaux.
+      
+      Ces données sont maintenues et analysées par la [Platform Governance Archive](https://www.platformgovernancearchive.org/) du [Center for Media Communication and Information Research (ZeMKI)](https://www.uni-bremen.de/zemki) de l'Université de Brême.
+      
+      Cette initiative offre aux chercheurs, journalistes et citoyens des outils pour analyser comment les plateformes structurent et régulent la communication et l’interaction dans nos sociétés.
+      
+      Elle vise également à promouvoir une transparence accrue et à renforcer la responsabilité de ces puissants services numériques.
+    governance:
+      sponsors:
+        - name: Ministère de l'Europe et des Affaires étrangères
+          url: https://www.diplomatie.gouv.fr
+          logo: https://opentermsarchive.org/images/contributors/meae.png

--- a/metadata.yml
+++ b/metadata.yml
@@ -22,29 +22,22 @@ trackingPeriods:
     schedule: "30 */12 * * *"
     serverLocation: Bremen, DE
 governance:
-  hosts:
-    - name: Centre for Media, Communication and Information Research
-      url: https://zemki.uni-bremen.de
-      logo: https://opentermsarchive.org/images/contributors/zemki.png
-  administrators:
-    - name: Open Terms Archive
-      url: https://opentermsarchive.org
-      logo: https://opentermsarchive.org/images/logo/logo-open-terms-archive-black-small.png
-  curators:
-    - name: Platform Governance Archive
-      url: https://www.platformgovernancearchive.org
-      logo: https://opentermsarchive.org/images/contributors/pga.png
-  maintainers:
-    - name: Platform Governance Archive
-      url: https://www.platformgovernancearchive.org
-      logo: https://opentermsarchive.org/images/contributors/pga.png
-  sponsors:
-    - name: Ministry for Europe and Foreign Affairs
-      url: https://www.diplomatie.gouv.fr/en/
-      logo: https://opentermsarchive.org/images/contributors/meae.png
-    - name: Centre for Media, Communication and Information Research
-      url: https://zemki.uni-bremen.de
-      logo: https://opentermsarchive.org/images/contributors/zemki.png
+  Centre for Media, Communication and Information Research:
+    url: https://zemki.uni-bremen.de
+    logo: https://opentermsarchive.org/images/contributors/zemki.png
+    roles: [host, sponsor]
+  Open Terms Archive:
+    url: https://opentermsarchive.org
+    logo: https://opentermsarchive.org/images/logo/logo-open-terms-archive-black-small.png
+    roles: [administrator]
+  Platform Governance Archive:
+    url: https://www.platformgovernancearchive.org
+    logo: https://opentermsarchive.org/images/contributors/pga.png
+    roles: [curator, maintainer]
+  Ministry for Europe and Foreign Affairs:
+    url: https://www.diplomatie.gouv.fr/en/
+    logo: https://opentermsarchive.org/images/contributors/meae.png
+    roles: [sponsor]
 
 i18n:
   fr: 
@@ -58,7 +51,6 @@ i18n:
       
       Elle vise également à promouvoir une transparence accrue et à renforcer la responsabilité de ces puissants services numériques.
     governance:
-      sponsors:
-        - name: Ministère de l'Europe et des Affaires étrangères
-          url: https://www.diplomatie.gouv.fr
-          logo: https://opentermsarchive.org/images/contributors/meae.png
+      Ministry for Europe and Foreign Affairs:
+        name: Ministère de l'Europe et des Affaires étrangères
+        url: https://www.diplomatie.gouv.fr

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "EUPL-1.2",
       "dependencies": {
-        "@opentermsarchive/engine": "~2.5.0",
+        "@opentermsarchive/engine": "~4.0.0",
         "isomorphic-fetch": "^3.0.0"
       }
     },
@@ -2253,9 +2253,9 @@
       "integrity": "sha512-AanzbulOHljrku1NGfafxdpTCfw2ENaWzH01N2vqQM+cUFbk868Cgh0xylz0JIM9BoKbfI++bdD6EYX0Q/UTEw=="
     },
     "node_modules/@opentermsarchive/engine": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentermsarchive/engine/-/engine-2.5.0.tgz",
-      "integrity": "sha512-ziZ+inihix3Y3cnqdhHsZQa+ZclLolGkIxz+ZrFYweDISZVA3ioe2LhBuTj2EPSYXhNS0jlK898lH1viiRowaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@opentermsarchive/engine/-/engine-4.0.0.tgz",
+      "integrity": "sha512-5PxDUTh2KG7cEVid0niU+uPMk6+5xVfCSLXaNQtwy7snvV9W7OJq5+VgKmFuO823kl2LsqjXELexJ0YhWB0n2A==",
       "dependencies": {
         "@accordproject/markdown-cicero": "^0.15.2",
         "@accordproject/markdown-pdf": "^0.15.2",
@@ -2291,6 +2291,7 @@
         "https-proxy-agent": "^5.0.0",
         "iconv-lite": "^0.6.3",
         "joplin-turndown-plugin-gfm": "^1.0.12",
+        "js-yaml": "^4.1.0",
         "jsdom": "^18.1.0",
         "json-source-map": "^0.6.1",
         "lodash": "^4.17.21",
@@ -2305,7 +2306,7 @@
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "sib-api-v3-sdk": "^8.2.1",
-        "simple-git": "^3.8.0",
+        "simple-git": "^3.27.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.0",
         "winston": "^3.9.0",
@@ -2318,7 +2319,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@opentermsarchive/terms-types": "^1.4.0"
+        "@opentermsarchive/terms-types": "^2.0.0"
       }
     },
     "node_modules/@opentermsarchive/fetch-charset-detection": {
@@ -2336,9 +2337,9 @@
       }
     },
     "node_modules/@opentermsarchive/terms-types": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentermsarchive/terms-types/-/terms-types-1.4.0.tgz",
-      "integrity": "sha512-LXfCGfjiv7JS6xxSPIgpBeS65WdIadF+gn2CagVtZM6OYmQIoNJ9sir7QZl6scrt0ZmA5CT7QOBzT7nMDhnUKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentermsarchive/terms-types/-/terms-types-2.0.0.tgz",
+      "integrity": "sha512-q6ck1vzVsxoLxaK1gA5DjgUB1YhBq4PbodchreCsC7bEcrxtKFrS5UhJZpRJpiu5e+orNJaFsDeIlU6QO5NaoA==",
       "peer": true
     },
     "node_modules/@opentermsarchive/turndown": {
@@ -9824,13 +9825,13 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.21.0.tgz",
-      "integrity": "sha512-oTzw9248AF5bDTMk9MrxsRzEzivMlY+DWH0yWS4VYpMhNLhDWnN06pCtaUyPnqv/FpsdeNmRqmZugMABHRPdDA==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
+        "debug": "^4.3.5"
       },
       "funding": {
         "type": "github",
@@ -9838,11 +9839,11 @@
       }
     },
     "node_modules/simple-git/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9852,6 +9853,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/simple-git/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "EUPL-1.2",
       "dependencies": {
-        "@opentermsarchive/engine": "~4.0.0",
+        "@opentermsarchive/engine": "~4.0.1",
         "isomorphic-fetch": "^3.0.0"
       }
     },
@@ -2253,9 +2253,9 @@
       "integrity": "sha512-AanzbulOHljrku1NGfafxdpTCfw2ENaWzH01N2vqQM+cUFbk868Cgh0xylz0JIM9BoKbfI++bdD6EYX0Q/UTEw=="
     },
     "node_modules/@opentermsarchive/engine": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@opentermsarchive/engine/-/engine-4.0.0.tgz",
-      "integrity": "sha512-5PxDUTh2KG7cEVid0niU+uPMk6+5xVfCSLXaNQtwy7snvV9W7OJq5+VgKmFuO823kl2LsqjXELexJ0YhWB0n2A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@opentermsarchive/engine/-/engine-4.0.1.tgz",
+      "integrity": "sha512-PRUoigd8HFrH5I0K1jTiSw2mrmsbl570xGCgxntEKNH42YoQw+gyYDZ9X0MytHpOmS/8mKUHgRe+FIeqpdngeQ==",
       "dependencies": {
         "@accordproject/markdown-cicero": "^0.15.2",
         "@accordproject/markdown-pdf": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dataset:schedule": "npm run dataset -- --publish --remove-local-copy --schedule"
   },
   "dependencies": {
-    "@opentermsarchive/engine": "~2.5.0",
+    "@opentermsarchive/engine": "~4.0.0",
     "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dataset:schedule": "npm run dataset -- --publish --remove-local-copy --schedule"
   },
   "dependencies": {
-    "@opentermsarchive/engine": "~4.0.0",
+    "@opentermsarchive/engine": "~4.0.1",
     "isomorphic-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
Following the recent [exposure of metadata](https://github.com/OpenTermsArchive/engine/pull/1123), that PR made the necessary change and additions to expose the PGA collection metadata through its collection API. This Metadata will be consumed by the Open Terms archive website.